### PR TITLE
'Fn::Transform' should only be an object

### DIFF
--- a/StringFunctions/string_example.yaml
+++ b/StringFunctions/string_example.yaml
@@ -12,35 +12,35 @@ Resources:
         - Key: Upper
           Value:
             'Fn::Transform':
-             - Name: 'String'
+               Name: 'String'
                Parameters:
                  InputString: !Ref InputString
                  Operation: Upper
         - Key: Lower
           Value:
             'Fn::Transform':
-             - Name: 'String'
+               Name: 'String'
                Parameters:
                  InputString: !Ref InputString
                  Operation: Lower
         - Key: Capitalize
           Value:
             'Fn::Transform':
-             - Name: 'String'
+               Name: 'String'
                Parameters:
                  InputString: !Ref InputString
                  Operation: Capitalize
         - Key: Title
           Value:
             'Fn::Transform':
-             - Name: 'String'
+               Name: 'String'
                Parameters:
                  InputString: !Ref InputString
                  Operation: Title
         - Key: Replace
           Value:
             'Fn::Transform':
-             - Name: 'String'
+               Name: 'String'
                Parameters:
                  InputString: !Ref InputString
                  Operation: Replace
@@ -49,7 +49,7 @@ Resources:
         - Key: Strip
           Value:
             'Fn::Transform':
-             - Name: 'String'
+               Name: 'String'
                Parameters:
                  InputString: !Ref InputString
                  Operation: Strip
@@ -57,7 +57,7 @@ Resources:
         - Key: ShortenLeft
           Value:
             'Fn::Transform':
-             - Name: 'String'
+               Name: 'String'
                Parameters:
                  InputString: !Ref InputString
                  Operation: MaxLength
@@ -66,7 +66,7 @@ Resources:
         - Key: ShortenRight
           Value:
             'Fn::Transform':
-             - Name: 'String'
+               Name: 'String'
                Parameters:
                  InputString: !Ref InputString
                  Operation: MaxLength


### PR DESCRIPTION
Removed the definition of Fn::Transform as a list of object to only be an object, inline with the [documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-transform.html).

*Issue #, if available:*

*Description of changes:*
Without this change, when passed to `aws cloudformation package` the template will cause the CLI to error out as it will try to invoke a `get` function on a list object which it assumes is a dict.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
