### PR TITLE
Correct StripFrom Right

### DIFF
--- a/StringFunctions/string.yaml
+++ b/StringFunctions/string.yaml
@@ -54,7 +54,9 @@ Resources:
                       elif "StripFrom" in event["params"]:
                           if event["params"]["StripFrom"] == "Left":
                               response["fragment"] = input[len(input)-length:]
-                          elif event["params"]["StripFrom"] != "Right":
+                          elif event["params"]["StripFrom"] == "Right":
+                              response["fragment"] = input[:length]
+                          else:
                               response["status"] = "failure"
                       else:
                           response["fragment"] = input[:length]


### PR DESCRIPTION
This commit implements a change to detect with StripFrom Right
exists in the parameters and return the fragment.
It also implements a change where StripFrom is in the parameters
but neither Left or Right is, and returns a failure.

To test the change, deploy the macro and launch the string_example.yaml
template.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
