### PR TITLE
Updated lambda runtime for boto3 macro

### DIFF
--- a/Boto3/macro.template
+++ b/Boto3/macro.template
@@ -4,7 +4,7 @@ Resources:
   ResourceFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: python2.7
+      Runtime: python3.9
       CodeUri: lambda
       Handler: resource.handler
       Policies: PowerUserAccess
@@ -12,7 +12,7 @@ Resources:
   MacroFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: python3.6
+      Runtime: python3.9
       CodeUri: lambda
       Handler: macro.handler
       Environment:

--- a/Count/template.yaml
+++ b/Count/template.yaml
@@ -16,5 +16,5 @@ Resources:
     Properties:
       CodeUri: src
       Handler: index.handler
-      Runtime: python3.6
+      Runtime: python3.9
       Timeout: 5


### PR DESCRIPTION
*Issue #16 , if available:*

*Description of changes:* Updated lambda runtime as per recommendation.

```
% cfn-lint macro.template 
E2531 Deprecated runtime (python2.7) specified. Updating disabled since 2021-09-30. Please consider updating to python3.9
macro.template:4:3

E2531 Deprecated runtime (python3.6) specified. Updating disabled since 2022-08-17. Please consider updating to python3.9
macro.template:12:3
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
