### PR TITLE
Update PyPlate Lambda-runtime to Python 3.11

### DIFF
--- a/PyPlate/python.yaml
+++ b/PyPlate/python.yaml
@@ -67,7 +67,7 @@ Resources:
               return macro_response
 
       Handler: index.handler
-      Runtime: python3.6
+      Runtime: python3.11
       Role: !GetAtt TransformExecutionRole.Arn
   TransformFunctionPermissions:
     Type: AWS::Lambda::Permission


### PR DESCRIPTION
Python 3.6 not supported anymore as Lambda-runtime